### PR TITLE
Use https for license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@
 
 ## License
 
-[The MIT License](http://piecioshka.mit-license.org) @ 2026
+[The MIT License](https://piecioshka.mit-license.org) @ 2026


### PR DESCRIPTION
Switches the README license link from http:// to https://piecioshka.mit-license.org.